### PR TITLE
chore: update GitHub Actions for semantic versioning and GHCR deployment

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build image and push to Docker Hub and GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
-          tags: ghcr.io/simonjamesrowe/strap-cms/strapi-cms:latest
+          tags: ghcr.io/simonjamesrowe/strapi-cms/strapi-cms:latest
           push: false

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a GitHub release
@@ -21,15 +21,17 @@ jobs:
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}``
+          body: ${{ steps.tag_version.outputs.changelog }}
       - name: Login to Github Packages
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build image and push to Docker Hub and GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
-          tags: ghcr.io/simonjamesrowe/strapi-cms/strapi-cms:${{ steps.tag_version.outputs.new_tag }}
+          tags: |
+            ghcr.io/simonjamesrowe/strapi-cms/strapi-cms:${{ steps.tag_version.outputs.new_tag }}
+            ghcr.io/simonjamesrowe/strapi-cms/strapi-cms:latest
           push: true


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions to latest stable versions
- Fix typo in Docker image repository name
- Add 'latest' tag alongside semantic version tags for automated deployment
- Improve semantic versioning configuration with updated github-tag-action

## Changes
- **branch-build.yml**: Update actions/checkout@v2 → v4, docker/build-push-action@v2 → v5, fix image name typo
- **master-build.yml**: Update all actions to latest versions, add 'latest' tag to Docker builds, fix changelog syntax error

## Test plan
- [x] Workflows pass syntax validation
- [ ] Branch builds successfully create Docker images without pushing
- [ ] Main branch builds create semantic version tags and GitHub releases
- [ ] Docker images are pushed to GHCR with both semantic version and 'latest' tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)