### PR TITLE
fix: use multi-arch Node.js base image for ARM64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM strapi/base
+FROM node:14-alpine
 
 WORKDIR /app
 
@@ -13,6 +13,6 @@ RUN yarn build
 
 EXPOSE 1337
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Problem
The previous workflow failed on ARM64 runners with:
```
exec /bin/sh: exec format error
Base image strapi/base was pulled with platform "linux/amd64", expected "linux/arm64"
```

## Solution
- Replace `strapi/base` with `node:14-alpine` which supports both AMD64 and ARM64
- Fix ENV syntax to modern format (`NODE_ENV=production`)

## Testing
This PR will trigger the multi-arch build workflow to verify both architectures build successfully.

Fixes the failed workflow run: https://github.com/simonjamesrowe/strapi-cms/actions/runs/18256499344