### PR TITLE
fix: add build dependencies for Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14-alpine
 
+# Install build dependencies for native modules
+RUN apk add --no-cache python3 make g++ vips-dev
+
 WORKDIR /app
 
 COPY ./package.json ./


### PR DESCRIPTION
## Problem
Docker builds failing with:
```
gyp ERR! find Python - "python" is not in PATH or produced an error
error /app/node_modules/sharp: Command failed
```

The `sharp` image processing library requires Python and build tools to compile native bindings, which are not included in the minimal Alpine base image.

## Solution
Install required build dependencies:
- `python3` - Required by node-gyp
- `make` & `g++` - C++ compiler toolchain
- `vips-dev` - Library for sharp image processing

## Testing
This PR will trigger the multi-arch build workflow to verify both AMD64 and ARM64 builds succeed.

Fixes workflow run: https://github.com/simonjamesrowe/strapi-cms/actions/runs/18256572188