### PR TITLE
fix: disable provenance attestation for Docker builds

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -66,6 +66,7 @@ jobs:
           context: .
           platforms: linux/${{ matrix.arch }}
           push: true
+          provenance: false
           tags: ghcr.io/simonjamesrowe/strapi-cms:${{ needs.version-and-release.outputs.new_tag }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.title=strapi-cms


### PR DESCRIPTION
## Problem
Multi-arch manifest creation failing with:
```
ghcr.io/simonjamesrowe/strapi-cms:v0.1.2-amd64 is a manifest list
Process completed with exit code 1
```

Docker build-push-action v5 automatically creates provenance attestations, which generates a manifest list instead of a single-platform image. This prevents `docker manifest create` from combining the images.

## Solution
- Add `provenance: false` to disable automatic attestation generation
- Ensures each architecture builds a single-platform image
- Allows `docker manifest create` to properly combine them into multi-arch manifests

## Testing
This PR will trigger the full workflow to verify:
- Both AMD64 and ARM64 builds succeed
- Multi-arch manifest creation completes successfully
- All semantic version tags are created

Fixes workflow run: https://github.com/simonjamesrowe/strapi-cms/actions/runs/18258082702