### PR TITLE
fix: add MongoDB setup and use Node 12 for Strapi 3.1.4 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:12-alpine
 
 # Install build dependencies for native modules
 RUN apk add --no-cache python3 make g++ vips-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  strapi:
+    image: ghcr.io/simonjamesrowe/strapi-cms:latest
+    container_name: strapi-cms
+    restart: unless-stopped
+    environment:
+      DATABASE_HOST: mongo
+      DATABASE_PORT: 27017
+      DATABASE_NAME: strapi
+      DATABASE_USERNAME: strapi
+      DATABASE_PASSWORD: strapi
+      NODE_ENV: production
+    ports:
+      - "1337:1337"
+    depends_on:
+      - mongo
+    networks:
+      - strapi-network
+
+  mongo:
+    image: mongo:4.4
+    container_name: strapi-mongo
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: strapi
+      MONGO_INITDB_ROOT_PASSWORD: strapi
+      MONGO_INITDB_DATABASE: strapi
+    volumes:
+      - strapi-data:/data/db
+    networks:
+      - strapi-network
+
+volumes:
+  strapi-data:
+
+networks:
+  strapi-network:
+    driver: bridge


### PR DESCRIPTION
## Problem
Container fails to start with errors:
```
TypeError: Cannot read property '_id' of null
Bootstrap function in plugin "users-permissions" failed
```

Root causes:
1. **No database configured** - Strapi needs MongoDB but container was running without it
2. **Node version incompatibility** - Strapi 3.1.4 was designed for Node 12, using Node 14 causes circular dependency warnings

## Solution

### Added docker-compose.yml
- MongoDB 4.4 service with persistent volume
- Properly configured database environment variables
- Network setup for service communication

### Downgraded to Node 12
- Changed from `node:14-alpine` to `node:12-alpine`
- Node 12 is the recommended version for Strapi 3.1.4
- Eliminates circular dependency warnings

## Usage
```bash
docker-compose up -d
```

This will start both Strapi and MongoDB together with proper configuration.